### PR TITLE
Fix code scanning alert no. 6: Unsigned difference expression compared to zero

### DIFF
--- a/src/naemon/macros.c
+++ b/src/naemon/macros.c
@@ -76,7 +76,7 @@ static const struct macro_key_code *find_macro_key(const char *name)
 	struct macro_key_code *key;
 
 	high = MACRO_X_COUNT;
-	while (high - low > 0) {
+	while (high > low) {
 		unsigned int mid = low + ((high - low) / 2);
 		key = &macro_keys[mid];
 		value = strcmp(name, key->name);


### PR DESCRIPTION
Fixes [https://github.com/sni/naemon-core/security/code-scanning/6](https://github.com/sni/naemon-core/security/code-scanning/6)

To fix the problem, we need to replace the comparison `high - low > 0` with `high > low`. This change will make the code clearer and avoid any confusion related to unsigned arithmetic. The fix involves modifying the condition in the `while` loop on line 79.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
