### PR TITLE
Fix code scanning alert no. 5: Multiplication result converted to larger type

### DIFF
--- a/src/naemon/utils.c
+++ b/src/naemon/utils.c
@@ -879,7 +879,7 @@ int generate_check_stats(void)
 			}
 			/* otherwise use weighted % of this and last bucket */
 			else {
-				bucket_value = (int)(ceil(this_bucket_value * this_bucket_weight) + floor(last_bucket_value * last_bucket_weight));
+				bucket_value = (int)(ceil(this_bucket_value * this_bucket_weight) + floor((double)last_bucket_value * last_bucket_weight));
 			}
 
 			/* 1 minute stats */


### PR DESCRIPTION
Fixes [https://github.com/sni/naemon-core/security/code-scanning/5](https://github.com/sni/naemon-core/security/code-scanning/5)

To fix the problem, we need to ensure that the multiplication is performed using the `double` type to avoid overflow. This can be achieved by casting one of the operands to `double` before the multiplication. Specifically, we can cast `last_bucket_value` to `double` before multiplying it by `last_bucket_weight`. This change ensures that the multiplication is done in the `double` type, preventing overflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
