### PR TITLE
Fix code scanning alert no. 1: Multiplication result converted to larger type

### DIFF
--- a/src/naemon/sretention.c
+++ b/src/naemon/sretention.c
@@ -44,7 +44,7 @@ int initialize_retention_data()
 
 	/* add a retention data save event if needed */
 	if (retain_state_information == TRUE && retention_update_interval > 0)
-		schedule_event(retention_update_interval * interval_length, save_state_information_eventhandler, NULL);
+		schedule_event((time_t)retention_update_interval * interval_length, save_state_information_eventhandler, NULL);
 
 	return xrddefault_initialize_retention_data();
 }


### PR DESCRIPTION
Fixes [https://github.com/sni/naemon-core/security/code-scanning/1](https://github.com/sni/naemon-core/security/code-scanning/1)

To fix the problem, we need to ensure that the multiplication is performed using the larger type (`time_t`) to avoid overflow. This can be done by casting one of the operands to `time_t` before performing the multiplication. This way, the multiplication will be done in the larger type, preventing overflow.

- Cast one of the operands (`retention_update_interval` or `interval_length`) to `time_t` before the multiplication.
- This change should be made in the `initialize_retention_data` function on line 47.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
