### PR TITLE
Fix code scanning alert no. 7: Multiplication result converted to larger type

### DIFF
--- a/src/naemon/utils.c
+++ b/src/naemon/utils.c
@@ -879,7 +879,7 @@ int generate_check_stats(void)
 			}
 			/* otherwise use weighted % of this and last bucket */
 			else {
-				bucket_value = (int)(ceil(this_bucket_value * this_bucket_weight) + floor((double)last_bucket_value * last_bucket_weight));
+				bucket_value = (int)(ceil((double)this_bucket_value * this_bucket_weight) + floor((double)last_bucket_value * last_bucket_weight));
 			}
 
 			/* 1 minute stats */


### PR DESCRIPTION
Fixes [https://github.com/sni/naemon-core/security/code-scanning/7](https://github.com/sni/naemon-core/security/code-scanning/7)

To fix the problem, we need to ensure that the multiplication is performed using a larger type to avoid overflow. Specifically, we should cast `this_bucket_value` to `double` before performing the multiplication. This ensures that the multiplication is done in the `double` type, which has a larger range and can handle larger values without overflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
