### PR TITLE
Fix code scanning alert no. 2: Multiplication result converted to larger type

### DIFF
--- a/src/naemon/sretention.c
+++ b/src/naemon/sretention.c
@@ -24,7 +24,7 @@ void save_state_information_eventhandler(struct nm_event_execution_properties *e
 	int status;
 
 	if (evprop->execution_type == EVENT_EXEC_NORMAL) {
-		schedule_event(retention_update_interval * interval_length, save_state_information_eventhandler, evprop->user_data);
+		schedule_event((time_t)retention_update_interval * interval_length, save_state_information_eventhandler, evprop->user_data);
 
 		status = save_state_information(TRUE);
 


### PR DESCRIPTION
Fixes [https://github.com/sni/naemon-core/security/code-scanning/2](https://github.com/sni/naemon-core/security/code-scanning/2)

To fix the problem, we need to ensure that the multiplication is performed using the larger type (`time_t`) to avoid overflow. This can be achieved by casting one of the operands to `time_t` before performing the multiplication. This way, the multiplication will be done in the larger type, preventing overflow.

- **General Fix:** Cast one of the operands to `time_t` before the multiplication.
- **Detailed Fix:** In the file `src/naemon/sretention.c`, on line 27, cast `retention_update_interval` to `time_t` before multiplying it by `interval_length`.
- **Specific Changes:** Modify the line `schedule_event(retention_update_interval * interval_length, save_state_information_eventhandler, evprop->user_data);` to `schedule_event((time_t)retention_update_interval * interval_length, save_state_information_eventhandler, evprop->user_data);`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
